### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/plugin/sample_plugin.rb
+++ b/lib/lolcommits/plugin/sample_plugin.rb
@@ -59,7 +59,7 @@ module Lolcommits
       # Prints a short (emoji themed) message to STDOUT
       #
       def run_pre_capture
-        puts "✨  Say cheese 😁 !"
+        puts "✨  Say cheese 😁 !" if configuration[:ask_for_cheese]
       end
 
       ##
@@ -72,7 +72,7 @@ module Lolcommits
       # Prints a short (emoji themed) message to STDOUT
       #
       def run_post_capture
-        puts "📸  Snap "
+        puts "#{"📸  " * configuration[:message][:emoji_multiplier].to_i}Snap!"
       end
 
       ##
@@ -87,7 +87,9 @@ module Lolcommits
       # sha.
       #
       def run_capture_ready
-        puts "✨  wow! #{self.runner.sha} is your best looking commit yet! 😘  💻"
+        if configuration[:always_a_great_commit?]
+          puts "✨  wow! #{self.runner.sha} is your best looking commit yet! 😘  💻"
+        end
       end
 
       ##
@@ -124,6 +126,17 @@ module Lolcommits
       #
       def configure_options!
         super
+      end
+
+      def default_options
+        {
+          "enabled" => false,
+          ask_for_cheese: true,
+          always_a_great_commit?: true,
+          message: {
+            emoji_multiplier: 1
+          }
+        }
       end
 
       ##

--- a/lib/lolcommits/sample_plugin/version.rb
+++ b/lib/lolcommits/sample_plugin/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module SamplePlugin
-    VERSION = "0.0.1".freeze
+    VERSION = "0.0.2".freeze
   end
 end

--- a/lolcommits-plugin-sample.gemspec
+++ b/lolcommits-plugin-sample.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.8"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"

--- a/test/lolcommits/plugin/sample_plugin_test.rb
+++ b/test/lolcommits/plugin/sample_plugin_test.rb
@@ -14,9 +14,7 @@ describe Lolcommits::Plugin::SamplePlugin do
   describe 'with a runner' do
     def runner
       # a simple lolcommits runner with an empty configuration Hash
-      @runner ||= Lolcommits::Runner.new(
-        config: OpenStruct.new(read_configuration: {})
-      )
+      @runner ||= Lolcommits::Runner.new
     end
 
     def plugin
@@ -24,22 +22,18 @@ describe Lolcommits::Plugin::SamplePlugin do
     end
 
     def valid_enabled_config
-      @config ||= OpenStruct.new(
-        read_configuration: {
-          plugin.class.name => { 'enabled' => true }
+      {
+        enabled: true,
+        ask_for_cheese: false,
+        always_a_great_commit?: true,
+        camera_emoji: {
+          enabled: true,
+          emoji_multiplier: 5
         }
-      )
-    end
-
-    describe 'initalizing' do
-      it 'should assign runner and an enabled option' do
-        plugin.runner.must_equal runner
-        plugin.options.must_equal ['enabled']
-      end
+      }
     end
 
     describe '#run_pre_capture' do
-
       before { commit_repo_with_message }
 
       it 'should output a message to stdout' do
@@ -68,33 +62,24 @@ describe Lolcommits::Plugin::SamplePlugin do
 
     describe '#enabled?' do
       it 'should be false by default' do
-        plugin.enabled?.must_equal false
+        assert_nil plugin.enabled?
       end
 
       it 'should true when configured' do
-        plugin.config = valid_enabled_config
+        plugin.configuration = valid_enabled_config
         plugin.enabled?.must_equal true
       end
     end
 
     describe 'configuration' do
-      it 'should not be configured by default' do
-        plugin.configured?.must_equal false
-      end
-
       it 'should allow plugin options to be configured' do
         configured_plugin_options = {}
 
-        output = fake_io_capture(inputs: %w(true)) do
+        output = fake_io_capture(inputs: %w(true false true true 5)) do
           configured_plugin_options = plugin.configure_options!
         end
 
-        configured_plugin_options.must_equal( { "enabled" => true })
-      end
-
-      it 'should indicate when configured' do
-        plugin.config = valid_enabled_config
-        plugin.configured?.must_equal true
+        configured_plugin_options.must_equal(valid_enabled_config)
       end
 
       describe '#valid_configuration?' do
@@ -103,7 +88,7 @@ describe Lolcommits::Plugin::SamplePlugin do
         end
 
         it 'should be true for a valid configuration' do
-          plugin.config = valid_enabled_config
+          plugin.configuration = valid_enabled_config
           plugin.valid_configuration?.must_equal true
         end
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 # necessary libs from lolcommits (allowing plugin to run)
 require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* sample plugin now makes use of `default_options`
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version (for new plugin release)
